### PR TITLE
Adjust pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,6 @@ repos:
     additional_dependencies:
       - flake8-quotes
       - flake8-comprehensions
-      - flake8-black
       - flake8-builtins
       - flake8-eradicate
       - pep8-naming
@@ -36,7 +35,7 @@ repos:
   rev: v4.3.4
   hooks:
   - id: isort
-- repo: https://github.com/ambv/black
+- repo: https://github.com/psf/black
   rev: stable
   hooks:
   - id: black

--- a/src/RIMEz/beam_models.py
+++ b/src/RIMEz/beam_models.py
@@ -196,7 +196,7 @@ def gaussian_dipole(alt, az, a):
     # multiply by 2*J_1(arg)/arg, J_1(x) is the bessel function
     # of the first kind
 
-    G = np.exp(-(np.pi / 2.0 - alt) ** 2.0 / 2.0 / a ** 2.0)
+    G = np.exp(-((np.pi / 2.0 - alt) ** 2.0) / 2.0 / a ** 2.0)
 
     # '00' <-> 'East,Alt', '01' <-> 'East,Az',
     # '10' <-> 'North,Alt', '11' <-> 'North,Az'


### PR DESCRIPTION
This PR removes the `flake8-black` check, because we explicitly include `black` as a separate pre-commit hook. We also switch the upstream version of `black` to be `psf` instead of `ambv`, because the latter seems to have stopped receiving updates. There is also a small change made that the more recent version of `black` catches.